### PR TITLE
Update blocky client to use asfpy.pubsub

### DIFF
--- a/blocky.yaml
+++ b/blocky.yaml
@@ -1,6 +1,6 @@
 # Blocky/4 configuration #
 api_host:         https://blocky.apache.org/
-pubsub_host:      https://pubsub.apache.org:2070/
+pubsub_host:      https://pubsub.apache.org:2070/blocky
 update_interval:  300
 chains: 
   - INPUT

--- a/blocky4-client.py
+++ b/blocky4-client.py
@@ -24,6 +24,7 @@ import asfpy.syslog
 import asfpy.whoami
 import asfpy.pubsub
 import aiohttp
+import sys
 
 MAX_BLOCK_SIZE_IPV4 = (2 ** 16)  # Max a /16 block in IPv4 space (32 - 16 == /16)
 MAX_BLOCK_SIZE_IPV6 = (2 ** 72)  # Max a /56 block in IPv6 space (128 - 72 == /56)
@@ -178,9 +179,14 @@ def main():
     if "whoami" not in config:
         config["whoami"] = asfpy.whoami.whoami()
     config["api_host"] = config["api_host"].rstrip("/")
-    # Start async loop
-    asyncio.get_event_loop().run_until_complete(loop(config))
-
+    
+    # Default modern behavior (Python>=3.7)
+    if sys.version_info.minor >= 7:
+        asyncio.run(loop(config))
+    # Python<=3.6 fallback
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(loop(config))
 
 if __name__ == "__main__":
     main()

--- a/blocky4-client.py
+++ b/blocky4-client.py
@@ -155,12 +155,13 @@ async def loop(config):
                 assert rv.status == 200, f"API host responded with bad status: {rv.status}"
                 js = await rv.json()
                 await process_changes(config, chains, allow=js["allow"], block=js["block"])
+                break
             except Exception as e:
                 print("[%u] Connection failed (%s: %s), reconnecting in 30 seconds" % (time.time(), type(e), e))
                 await asyncio.sleep(30)
 
     # Attach to pubsub and listen for new blocks/allows
-    async for payload in asfpy.pubsub.listen(self.config["pubsub_host"]):
+    async for payload in asfpy.pubsub.listen(config["pubsub_host"]):
         if "blocky" in payload.get("pubsub_topics", []):
             if "block" in payload:
                 await process_changes(config, chains, block=[payload["block"]])

--- a/blocky4-client.py
+++ b/blocky4-client.py
@@ -168,7 +168,7 @@ async def loop(config):
         # Time to re-upload our own current list of bans?
         if last_upload + config.get("upload_interval", 300) < time.time():
             await upload_iptables(config, chains)
-                last_upload = time.time()
+            last_upload = time.time()
 
 
 

--- a/blocky4-client.py
+++ b/blocky4-client.py
@@ -185,8 +185,8 @@ def main():
         asyncio.run(loop(config))
     # Python<=3.6 fallback
     else:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(loop(config))
+        current_loop = asyncio.get_event_loop()
+        current_loop.run_until_complete(loop(config))
 
 if __name__ == "__main__":
     main()

--- a/blocky4-client.py
+++ b/blocky4-client.py
@@ -168,7 +168,7 @@ async def loop(config):
         # Time to re-upload our own current list of bans?
         if last_upload + config.get("upload_interval", 300) < time.time():
             await upload_iptables(config, chains)
-                    last_upload = time.time()
+                last_upload = time.time()
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests>=2.23.0
 netaddr>=0.7.19
 websockets>=8.1
 PyYAML>=5.3.1
-asfpy>=0.28
+asfpy>=0.46
 aiohttp


### PR DESCRIPTION
This updates blocky client to use asfpy.pubsub for events.
Also adds a compatibility layer for python 3.6 and below, and tweaks the pubsub URL slightly for less noise.